### PR TITLE
Fix multiple security and parsing bugs

### DIFF
--- a/src/Core/View.php
+++ b/src/Core/View.php
@@ -203,6 +203,8 @@ class View
      * Escapes a string for safe use in JavaScript.
      *
      * Useful for onclick attributes and other inline JavaScript contexts.
+     * Also escapes Unicode line terminators (U+2028, U+2029) which are
+     * valid in JSON but treated as line terminators in JavaScript.
      *
      * @param mixed $value Value to escape.
      * @return string Value escaped for JavaScript.
@@ -217,6 +219,10 @@ class View
 
         // Escape control characters, quotes and backslashes
         $escaped = addcslashes($string, "\0..\37\"'\\");
+
+        // Escape Unicode line terminators (U+2028, U+2029)
+        // These are valid in JSON but treated as line terminators in JavaScript
+        $escaped = str_replace(["\u{2028}", "\u{2029}"], ['\\u2028', '\\u2029'], $escaped);
 
         // Escape sequences that could break out of script context
         $escaped = str_replace(['</', '<!--', '-->'], ['<\\/', '<\\!--', '--\\>'], $escaped);

--- a/src/Models/FileHandler.php
+++ b/src/Models/FileHandler.php
@@ -271,6 +271,14 @@ class FileHandler
             if (!empty($ext)) {
                 // Calculate max base length: 255 - dot (1) - extension length
                 $maxBaseLength = 255 - 1 - strlen($ext);
+
+                // If extension is too long, truncate the extension instead
+                if ($maxBaseLength < 1) {
+                    $maxExtLength = 255 - 1 - 1; // 253 chars for extension, 1 for base, 1 for dot
+                    $ext = substr($ext, 0, $maxExtLength);
+                    $maxBaseLength = 1;
+                }
+
                 // Find the dot position to get the base name
                 $dotPos = strrpos($filename, '.');
                 $base = substr($filename, 0, min($dotPos, $maxBaseLength));

--- a/src/Services/AjaxService.php
+++ b/src/Services/AjaxService.php
@@ -832,7 +832,8 @@ JAVASCRIPT;
      * Escapes a string for safe use in JavaScript.
      *
      * Prevents XSS injections by escaping special characters,
-     * including sequences that could terminate a script block.
+     * including sequences that could terminate a script block
+     * and Unicode line terminators (U+2028, U+2029).
      *
      * @param string $string String to escape
      * @return string JavaScript-safe string
@@ -841,6 +842,10 @@ JAVASCRIPT;
     {
         // Escape control characters, quotes and backslashes
         $escaped = addcslashes($string, "\0..\37\"'\\");
+
+        // Escape Unicode line terminators (U+2028, U+2029)
+        // These are valid in JSON but treated as line terminators in JavaScript
+        $escaped = str_replace(["\u{2028}", "\u{2029}"], ['\\u2028', '\\u2029'], $escaped);
 
         // Escape sequences that could break out of script context
         // </script> could terminate the script block prematurely


### PR DESCRIPTION
- Config: Remove /*! and DELIMITER from comment_markers (MySQL conditional comments contain valid SQL code that should be executed)
- Config: Fix legacy config file variable extraction that was returning empty config instead of extracted variables
- Request: Reject scientific notation in getInt() and add overflow protection
- View/AjaxService: Add Unicode line terminator escaping (U+2028, U+2029) to prevent XSS in JavaScript contexts
- FileHandler: Fix filename truncation when extension is very long