### PR TITLE
by ClaudeCode - Fix additional bugs in SqlParser and Database

### DIFF
--- a/src/Models/Database.php
+++ b/src/Models/Database.php
@@ -111,8 +111,8 @@ class Database
             }
 
             if (!$this->connection->set_charset($safeCharset)) {
-                // Fallback with SET NAMES
-                $this->connection->query("SET NAMES `{$safeCharset}`");
+                // Fallback with SET NAMES (no quotes/backticks - charset is already validated)
+                $this->connection->query("SET NAMES {$safeCharset}");
             }
         }
 

--- a/src/Models/SqlParser.php
+++ b/src/Models/SqlParser.php
@@ -97,7 +97,9 @@ class SqlParser
         $this->delimiter = $config->get('delimiter', ';');
         // Support both single and double quotes for SQL strings
         $this->stringQuotes = ["'", '"'];
-        $this->commentMarkers = $config->get('comment_markers', ['#', '-- ', '/*!']);
+        // Note: /*! (MySQL conditional comments) are NOT in the default list
+        // because they contain valid SQL code that MySQL executes
+        $this->commentMarkers = $config->get('comment_markers', ['#', '-- ']);
         $this->maxQueryLines = $config->get('max_query_lines', 10000);
         $this->maxQueryMemory = $config->get('max_query_memory', 10485760);
     }


### PR DESCRIPTION
- SqlParser: Remove /*! from default comment_markers fallback (consistency with Config.php fix - MySQL conditional comments contain valid SQL that should be executed)
- Database: Fix SET NAMES syntax - remove backticks around charset (MySQL SET NAMES doesn't accept backticks)