### PR TITLE
Speed up database migration import time

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -61,8 +61,20 @@ class Config
             '-- ',
         ],
 
-        // SQL pre-queries
-        'pre_queries' => [],
+        // SQL pre-queries - Performance optimizations enabled by default
+        'pre_queries' => [
+            'SET autocommit=0',
+            'SET unique_checks=0',
+            'SET foreign_key_checks=0',
+            'SET sql_log_bin=0',
+        ],
+
+        // SQL post-queries - Restore settings after import
+        'post_queries' => [
+            'SET unique_checks=1',
+            'SET foreign_key_checks=1',
+            'SET autocommit=1',
+        ],
 
         // Default query delimiter
         'delimiter' => ';',

--- a/src/Models/SqlParser.php
+++ b/src/Models/SqlParser.php
@@ -272,6 +272,9 @@ class SqlParser
     /**
      * Analyzes quotes in a line to determine in-string state
      *
+     * OPTIMIZED: Uses strpos() to jump directly to quote positions
+     * instead of iterating character by character.
+     *
      * This method properly handles:
      * - Both single quotes (') and double quotes (")
      * - Double backslashes (\\) before quotes
@@ -284,47 +287,72 @@ class SqlParser
     private function analyzeQuotes(string $line): void
     {
         $length = strlen($line);
-        $i = 0;
+        $pos = 0;
 
-        while ($i < $length) {
-            $char = $line[$i];
-
+        while ($pos < $length) {
             if ($this->inString) {
-                // In a string, look for the matching closing quote
-                if ($char === $this->activeQuote) {
-                    // Check if it's a doubled quote (SQL escape: '' -> ' or "" -> ")
-                    if ($i + 1 < $length && $line[$i + 1] === $this->activeQuote) {
-                        // Doubled quote, skip both characters, stay in string
-                        $i += 2;
-                        continue;
-                    }
+                // Find the next occurrence of the active quote
+                $quotePos = strpos($line, $this->activeQuote, $pos);
 
-                    // Count preceding backslashes
-                    $backslashes = 0;
-                    $j = $i - 1;
-
-                    while ($j >= 0 && $line[$j] === '\\') {
-                        $backslashes++;
-                        $j--;
-                    }
-
-                    // If even number of backslashes (or zero), quote closes the string
-                    // If odd number, quote is escaped
-                    if ($backslashes % 2 === 0) {
-                        $this->inString = false;
-                        $this->activeQuote = '';
-                    }
+                if ($quotePos === false) {
+                    // No closing quote found in this line
+                    return;
                 }
+
+                // Check if it's a doubled quote (SQL escape: '' or "")
+                if ($quotePos + 1 < $length && $line[$quotePos + 1] === $this->activeQuote) {
+                    // Skip both characters, stay in string
+                    $pos = $quotePos + 2;
+                    continue;
+                }
+
+                // Count preceding backslashes
+                $backslashes = 0;
+                $j = $quotePos - 1;
+                while ($j >= 0 && $line[$j] === '\\') {
+                    $backslashes++;
+                    $j--;
+                }
+
+                // If even number of backslashes (or zero), quote closes the string
+                if ($backslashes % 2 === 0) {
+                    $this->inString = false;
+                    $this->activeQuote = '';
+                }
+
+                $pos = $quotePos + 1;
             } else {
-                // Outside string, look for the beginning of a string
-                // Check both single and double quotes
-                if (in_array($char, $this->stringQuotes, true)) {
-                    $this->inString = true;
-                    $this->activeQuote = $char;
-                }
-            }
+                // Find the next single or double quote
+                $singlePos = strpos($line, "'", $pos);
+                $doublePos = strpos($line, '"', $pos);
 
-            $i++;
+                // Determine which quote comes first
+                if ($singlePos === false && $doublePos === false) {
+                    // No quotes found
+                    return;
+                }
+
+                if ($singlePos === false) {
+                    $nextQuotePos = $doublePos;
+                    $quoteChar = '"';
+                } elseif ($doublePos === false) {
+                    $nextQuotePos = $singlePos;
+                    $quoteChar = "'";
+                } else {
+                    // Both found, take the first one
+                    if ($singlePos < $doublePos) {
+                        $nextQuotePos = $singlePos;
+                        $quoteChar = "'";
+                    } else {
+                        $nextQuotePos = $doublePos;
+                        $quoteChar = '"';
+                    }
+                }
+
+                $this->inString = true;
+                $this->activeQuote = $quoteChar;
+                $pos = $nextQuotePos + 1;
+            }
         }
     }
 


### PR DESCRIPTION
- Add MySQL pre-queries by default (autocommit=0, unique_checks=0, foreign_key_checks=0, sql_log_bin=0) for significant speed boost
- Add post-queries to restore settings after import completion
- Optimize SqlParser::analyzeQuotes() using strpos() instead of character-by-character iteration (O(1) jumps vs O(n) scan)
- Optimize InsertBatcherService::parseSimpleInsert() using string functions instead of complex regex patterns
- Add buffered reading in FileHandler (64KB buffer) to reduce system calls and improve I/O performance
- Fix tell()/seek()/eof() to properly handle the read buffer