### PR TITLE
Fix #48: handle open_basedir restriction when reading /proc/meminfo

### DIFF
--- a/src/Services/AutoTunerService.php
+++ b/src/Services/AutoTunerService.php
@@ -933,16 +933,30 @@ class AutoTunerService
 
     /**
      * Get memory info on Linux by reading /proc/meminfo (no shell execution)
+     *
+     * Wrapped in a try/catch and using the @-operator because some shared
+     * hosting environments restrict access to /proc via open_basedir. In that
+     * case is_readable()/file_get_contents() emit warnings (which the global
+     * error handler turns into exceptions); we swallow them and fall back to
+     * PHP-based memory estimation instead of crashing. See issue #48.
      */
     private function getLinuxMemory(): ?array
     {
         $meminfo = '/proc/meminfo';
 
-        if (!is_readable($meminfo)) {
+        try {
+            // The @-operator silences open_basedir warnings so the global
+            // error handler does not promote them to an ErrorException.
+            if (!@is_readable($meminfo)) {
+                return null;
+            }
+
+            $content = @file_get_contents($meminfo);
+        } catch (\Throwable $e) {
+            // open_basedir or any other restriction: degrade gracefully.
             return null;
         }
 
-        $content = @file_get_contents($meminfo);
         if ($content === false) {
             return null;
         }


### PR DESCRIPTION
## Problem

On shared hosting, `open_basedir` frequently blocks access to `/proc`. In `AutoTunerService::getLinuxMemory()`, the unguarded `is_readable('/proc/meminfo')` call emitted a warning:

```
is_readable(): open_basedir restriction in effect. File(/proc/meminfo) is not within the allowed path(s) ...
```

The application's global error handler (`index.php`) promotes warnings to `ErrorException`, so this crashed the app with **"Application Error"** at `AutoTunerService.php:941`.

Fixes #48.

## Fix

- Silence the `open_basedir` warning on `is_readable()` with the `@`-operator, so the global error handler no longer promotes it to an exception (the handler honors `error_reporting()`, which `@` sets to `0`).
- Wrap the `/proc/meminfo` read in a `try/catch` for defense-in-depth, so any restriction degrades gracefully.
- When access is blocked, the service now falls through to the existing PHP `memory_limit`-based fallback estimation instead of failing.

## Testing

- `php -l` passes on the modified file.
- `tests/AutoTunerProfileTest.php` — all 7 tests pass.
- Verified that the `@`-operator prevents the global error handler from promoting the warning into an `ErrorException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ra3y8Y3Fge7eL2FNfecWi)_